### PR TITLE
Add support for file uploads from curl

### DIFF
--- a/archeryapi/urls.py
+++ b/archeryapi/urls.py
@@ -57,7 +57,7 @@ urlpatterns = [
     path('netsparkerscanstatus/', views.NetsparkerScanStatus.as_view()),
     path('webinspectscanstatus/', views.WebinspectScanStatus.as_view()),
     path('acunetixscanresult/', views.AcunetixScanStatus.as_view()),
-    path('uploadscan/', views.UpladScanResult.as_view()),
+    path('uploadscan/', views.UploadScanResult.as_view()),
     path('zapstatusupdate/', views.UpdateZapStatus.as_view()),
     path('createuser/', views.CreateUsers.as_view())
 

--- a/archeryapi/views.py
+++ b/archeryapi/views.py
@@ -59,7 +59,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from staticscanners.models import bandit_scan_db, retirejs_scan_db
 from scanners.scanner_parser.staticscanner_parser.bandit_report_parser import bandit_report_json
 from django.contrib.auth.models import User
-from django.core.files.uploadedfile import TemporaryUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 from stronghold.decorators import public
 from webscanners.arachniscanner.views import launch_arachni_scan
 from scanners.scanner_parser.staticscanner_parser import dependencycheck_report_parser, \
@@ -628,7 +628,7 @@ class UploadScanResult(APIView):
         username = request.user.username
         project_id = request.data.get("project_id")
         scanner = request.data.get("scanner")
-        if isinstance(request.data.get("filename"),TemporaryUploadedFile):
+        if isinstance(request.data.get("filename"), UploadedFile):
             file = request.data.get("filename").read().decode("utf-8")
         else:
             file = request.data.get("filename")

--- a/archeryapi/views.py
+++ b/archeryapi/views.py
@@ -1189,7 +1189,7 @@ class UpladScanResult(APIView):
                              "scan_id": scan_id,
                              "scanner": scanner
                              })
-        
+
         elif scanner == 'twistlock':
             date_time = datetime.datetime.now()
             scan_dump = twistlock_scan_db(
@@ -1203,15 +1203,14 @@ class UpladScanResult(APIView):
             scan_dump.save()
             data = json.loads(file)
             gitlab_sast_json_report_parser.twistlock_report_json(project_id=project_id,
-                                                                  scan_id=scan_id,
-                                                                  data=data,
-                                                                  username=username)
+                                                                 scan_id=scan_id,
+                                                                 data=data,
+                                                                 username=username)
             return Response({"message": "Scan Data Uploaded",
                              "project_id": project_id,
                              "scan_id": scan_id,
                              "scanner": scanner
                              })
-
 
         elif scanner == 'brakeman':
             date_time = datetime.datetime.now()
@@ -1226,14 +1225,13 @@ class UpladScanResult(APIView):
             scan_dump.save()
             data = json.loads(file)
             brakeman_json_report_parser.brakeman_report_json(project_id=project_id,
-                                                                  scan_id=scan_id,
-                                                                  data=data,
-                                                                  username=username)
+                                                             scan_id=scan_id,
+                                                             data=data,
+                                                             username=username)
             return Response({"message": "Scan Data Uploaded",
                              "project_id": project_id,
                              "scan_id": scan_id,
                              "scanner": scanner
                              })
-
 
         return Response({"message": "Scan Data Uploaded"})

--- a/archeryapi/views.py
+++ b/archeryapi/views.py
@@ -628,7 +628,7 @@ class UploadScanResult(APIView):
         username = request.user.username
         project_id = request.data.get("project_id")
         scanner = request.data.get("scanner")
-        if type(request.data.get("filename")) == TemporaryUploadedFile:
+        if isinstance(request.data.get("filename"),TemporaryUploadedFile):
             file = request.data.get("filename").read().decode("utf-8")
         else:
             file = request.data.get("filename")

--- a/archeryapi/views.py
+++ b/archeryapi/views.py
@@ -59,6 +59,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from staticscanners.models import bandit_scan_db, retirejs_scan_db
 from scanners.scanner_parser.staticscanner_parser.bandit_report_parser import bandit_report_json
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import TemporaryUploadedFile
 from stronghold.decorators import public
 from webscanners.arachniscanner.views import launch_arachni_scan
 from scanners.scanner_parser.staticscanner_parser import dependencycheck_report_parser, \
@@ -620,14 +621,18 @@ class UpdateZapStatus(generics.CreateAPIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class UpladScanResult(APIView):
+class UploadScanResult(APIView):
     parser_classes = (MultiPartParser,)
 
     def post(self, request, format=None):
         username = request.user.username
         project_id = request.data.get("project_id")
         scanner = request.data.get("scanner")
-        file = request.data.get("filename")
+        if type(request.data.get("filename")) == TemporaryUploadedFile:
+            file = request.data.get("filename").read().decode("utf-8")
+        else:
+            file = request.data.get("filename")
+
         scan_url = request.data.get("scan_url")
         scan_id = uuid.uuid4()
         scan_status = "100"

--- a/archeryapi/views.py
+++ b/archeryapi/views.py
@@ -185,7 +185,6 @@ class NetworkScan(generics.ListCreateAPIView):
            Current user's identity endpoint.
 
         """
-        username = request.user.username
         user = request.user
         serializer = NetworkScanSerializer(data=request.data)
         if serializer.is_valid():
@@ -612,8 +611,6 @@ class UpdateZapStatus(generics.CreateAPIView):
 
     def post(self, request, format=None, **kwargs):
         username = request.user.username
-        _scan_id = None
-        _scan_status = None
         serializer = ZapScanStatusDataSerializers(data=request.data)
         if serializer.is_valid():
             scan_id = request.data.get("scan_id")


### PR DESCRIPTION
The upload scan api endpoint only seemed to support including a report as string content which complicates use in scripts so I added support for uploading a file using the following syntax (for example):

`curl --location --request POST "http://$IP:$PORT/api/uploadscan/" \
--header "Authorization: JWT $TOKEN" \
--form 'filename=@/path/to/dependency-check-report.xml' \
--form 'project_id="$PROJECT_ID"' \
--form 'scanner="dependencycheck"' \
`

I had to tidy the file a little prior to making changes to pass the Flake8 checks. I will add to the api documentation if this is merged. If I've missed something, you know of an already working way, or you have suggestions please let me know.