### PR TITLE
Allow link to results to still be used when no project exists in scan data

### DIFF
--- a/staticscanners/templates/banditscanner/banditscans_list.html
+++ b/staticscanners/templates/banditscanner/banditscans_list.html
@@ -91,7 +91,7 @@
                                             </form>
                                         </td>
                                 <td>
-                                    <a href="{% url 'banditscanner:banditscan_list_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                    <a href="{% url 'banditscanner:banditscan_list_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                 </td>
                             {% csrf_token %}
                                 <td width="20%">

--- a/staticscanners/templates/brakeman/brakeman_list.html
+++ b/staticscanners/templates/brakeman/brakeman_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'brakeman:brakeman_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'brakeman:brakeman_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/checkmarx/checkmarx_list.html
+++ b/staticscanners/templates/checkmarx/checkmarx_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'checkmarx:checkmarx_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'checkmarx:checkmarx_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                     {% csrf_token %}
                                         <td width="20%">

--- a/staticscanners/templates/clair/clairscans_list.html
+++ b/staticscanners/templates/clair/clairscans_list.html
@@ -140,7 +140,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'clair:clair_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'clair:clair_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/dependencycheck/dependencycheckscans_list.html
+++ b/staticscanners/templates/dependencycheck/dependencycheckscans_list.html
@@ -8,7 +8,7 @@
 <script type="text/javascript">
     function toreport(){
         var uuid = [];
-        $.each($("input[name='del_scan_id']:checked"), function(){            
+        $.each($("input[name='del_scan_id']:checked"), function(){
             uuid.push($(this).val());
         });
         //alert(uuid.join(", "));
@@ -141,7 +141,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'dependencycheck:dependencycheck_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'dependencycheck:dependencycheck_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/findbugs/findbugsscans_list.html
+++ b/staticscanners/templates/findbugs/findbugsscans_list.html
@@ -140,7 +140,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'findbugs:findbugs_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'findbugs:findbugs_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/gitlabcontainerscan/gitlabcontainerscans_list.html
+++ b/staticscanners/templates/gitlabcontainerscan/gitlabcontainerscans_list.html
@@ -132,7 +132,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'gitlabcontainerscan:gitlabcontainerscan_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'gitlabcontainerscan:gitlabcontainerscan_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/gitlabsast/gitlabsastscans_list.html
+++ b/staticscanners/templates/gitlabsast/gitlabsastscans_list.html
@@ -132,7 +132,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'gitlabsast:gitlabsast_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'gitlabsast:gitlabsast_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/gitlabsca/gitlabscascans_list.html
+++ b/staticscanners/templates/gitlabsca/gitlabscascans_list.html
@@ -132,7 +132,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'gitlabsca:gitlabsca_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'gitlabsca:gitlabsca_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/nodejsscan/nodejsscan_list.html
+++ b/staticscanners/templates/nodejsscan/nodejsscan_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'nodejsscan:nodejsscan_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'nodejsscan:nodejsscan_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/npmaudit/npmaudit_list.html
+++ b/staticscanners/templates/npmaudit/npmaudit_list.html
@@ -132,7 +132,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'npmaudit:npmaudit_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'npmaudit:npmaudit_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/retirejsscanner/retirejsscans_list.html
+++ b/staticscanners/templates/retirejsscanner/retirejsscans_list.html
@@ -90,7 +90,7 @@
                                     </form>
                                 </td>
                                 <td>
-                                    <a href="{% url 'banditscanner:banditscan_list_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                    <a href="{% url 'banditscanner:banditscan_list_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                 </td>
                                 <td width="20%">
                                     <div class="progress progress-info{% if data.scan_status != '100.0' %} active progress-striped{% endif %}">

--- a/staticscanners/templates/semgrepscan/semgrepscan_list.html
+++ b/staticscanners/templates/semgrepscan/semgrepscan_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'semgrepscan:semgrepscan_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'semgrepscan:semgrepscan_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/tfsec/tfsec_list.html
+++ b/staticscanners/templates/tfsec/tfsec_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'tfsec:tfsec_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'tfsec:tfsec_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/trivy/trivyscans_list.html
+++ b/staticscanners/templates/trivy/trivyscans_list.html
@@ -140,7 +140,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'trivy:trivy_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'trivy:trivy_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/twistlock/twistlock_list.html
+++ b/staticscanners/templates/twistlock/twistlock_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'twistlock:twistlock_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'twistlock:twistlock_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}}</a>
                                         </td>
                                         <td width="20%">
                                             <div>

--- a/staticscanners/templates/whitesource/whitesource_list.html
+++ b/staticscanners/templates/whitesource/whitesource_list.html
@@ -130,7 +130,7 @@
                                             </form>
                                         </td>
                                         <td>
-                                            <a href="{% url 'whitesource:whitesource_all_vuln' %}?scan_id={{data.scan_id}}">{{data.project_name}}</a>
+                                            <a href="{% url 'whitesource:whitesource_all_vuln' %}?scan_id={{data.scan_id}}">{% firstof data.project_name 'None' %}</a>
                                         </td>
                                     {% csrf_token %}
                                         <td width="20%">


### PR DESCRIPTION
The project field appears to come from scan data on some scanners, but when using Dependency check for example the field is empty. When empty you can't use the link to the results.